### PR TITLE
fixed issue in gutter with the git removed line indicator

### DIFF
--- a/stylesheets/base.less
+++ b/stylesheets/base.less
@@ -31,7 +31,7 @@ atom-text-editor, :host {
 
     .line-number {
       &.cursor-line {
-        background-color: @syntax-gutter-background-color-selected;
+        background-color: transparent;
         color: @syntax-gutter-text-color-selected;
       }
 


### PR DESCRIPTION
This is what the red triangle in the gutter (indicating that line has been removed since last git commit) looks like when line 121 is the cursor-line:

![atom outlander syntax gutter bug](https://cloud.githubusercontent.com/assets/3612514/6199204/1d7f5768-b436-11e4-93d0-4e1a358d6f2e.png)

By making the background-color transparent of the cursor-line's line-number, it will look like this:

![atom outlander syntax gutter bug fixed](https://cloud.githubusercontent.com/assets/3612514/6199205/1d8094f2-b436-11e4-96b7-8f26445ee6ae.png)
