### PR TITLE
Lighter selection background and link highlight for markdown

### DIFF
--- a/styles/base.less
+++ b/styles/base.less
@@ -296,6 +296,10 @@ atom-text-editor, :host {
   &.raw.inline {
     color: @green;
   }
+  
+  &.link {
+    color: @purple;
+  }
 }
 
 .source.gfm .markup {

--- a/styles/syntax-variables.less
+++ b/styles/syntax-variables.less
@@ -6,7 +6,7 @@
 // General colors
 @syntax-text-color: lighten(@very-light-gray, 5%);
 @syntax-cursor-color: white;
-@syntax-selection-color: lighten(@very-dark-gray, 5%);
+@syntax-selection-color: lighten(@very-dark-gray, 15%);
 @syntax-background-color: @very-dark-gray;
 
 // Guide colors


### PR DESCRIPTION
Hi,

First of all, just want to say thank you for creating this amazing syntax style. It is neat and gorgeous.

However, I found the background of selected words is not quite obvious and I made some mistakes when copy the selected words for several times. It makes me quite sad. I tried to lighten the background color a bit. Now it is clear enough for me to tell which part is selected or not.

I also added a link color for markup style. I am using Markdown with links a lot and it could be useful if the link is highlighted.

I attach a comparison below for a reference. 

Before: I can hardly see the selection, and no highlight for link:
![snip20151105_6](https://cloud.githubusercontent.com/assets/1019875/10971540/2b03b566-8418-11e5-9e29-9dc7b036d6c5.png)

After: I guess it is better than the original one.
![snip20151105_3](https://cloud.githubusercontent.com/assets/1019875/10971566/47958b50-8418-11e5-9154-b1aa217f95aa.png)

Of course, the color choice is heavily depending on personal favorite. So if you do not like this, just feel free to close this p-r and I will keep my own version for my personal use. 

Thank you!
